### PR TITLE
Forbid caching for API request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -244,10 +244,7 @@ namespace Private {
   }
 
   async function _requestDashboards(): Promise<void> {
-    const dashboardsMap = await requestAPI<ContainDS.IDashboards>(_endpoint, {
-      method: 'GET',
-      cache: 'no-cache'
-    });
+    const dashboardsMap = await requestAPI<ContainDS.IDashboards>(_endpoint);
 
     if (
       JSON.stringify(dashboardsMap) !== JSON.stringify(_dashboardsMap || {})

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,10 @@ namespace Private {
   }
 
   async function _requestDashboards(): Promise<void> {
-    const dashboardsMap = await requestAPI<ContainDS.IDashboards>(_endpoint);
+    const dashboardsMap = await requestAPI<ContainDS.IDashboards>(_endpoint, {
+      method: 'GET',
+      cache: 'no-cache'
+    });
 
     if (
       JSON.stringify(dashboardsMap) !== JSON.stringify(_dashboardsMap || {})

--- a/src/request.ts
+++ b/src/request.ts
@@ -55,7 +55,7 @@ export async function requestAPI<T>(
 ): Promise<T> {
   let response: Response;
   try {
-    response = await fetch(endPoint, init);
+    response = await fetch(endPoint, { ...init, cache: 'no-cache' });
   } catch (error) {
     throw new ServerConnection.NetworkError(error);
   }


### PR DESCRIPTION
Small mistake from my side - the request to the hub API must be done without caching. Currently the browser is actually not requesting a updated list of the dashboard (got 304 on the request).